### PR TITLE
deserialize changes using as_hash function if defined in query model

### DIFF
--- a/lib/nobrainer_streams.rb
+++ b/lib/nobrainer_streams.rb
@@ -32,8 +32,14 @@ module NoBrainer::Streams
       klass = query.model
       old_val = changes['old_val']
       new_val = changes['new_val']
-      changes['old_val'] = klass.new(old_val)  if old_val
-      changes['new_val'] = klass.new(new_val)  if new_val
+      if defined?(klass.as_hash)
+        changes['old_val'] = klass.new(old_val).as_hash if old_val
+        changes['new_val'] = klass.new(new_val).as_hash if new_val
+      else
+        changes['old_val'] = klass.new(old_val) if old_val
+        changes['new_val'] = klass.new(new_val) if new_val
+      end
+
       callback.call(changes)
     end
 

--- a/lib/nobrainer_streams.rb
+++ b/lib/nobrainer_streams.rb
@@ -32,7 +32,7 @@ module NoBrainer::Streams
       klass = query.model
       old_val = changes['old_val']
       new_val = changes['new_val']
-      if defined?(klass.as_hash)
+      if klass.method_defined?('as_hash')
         changes['old_val'] = klass.new(old_val).as_hash if old_val
         changes['new_val'] = klass.new(new_val).as_hash if new_val
       else


### PR DESCRIPTION
sometimes you need to include/remove certain attributes so define `as_hash` function and `changes` shall use it rather than using the hash generated by `Model.new`